### PR TITLE
Improve function signatures by clarify lifetime and accept by `Desc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ version = "0.1.0"
 dependencies = [
  "graphviz-rust",
  "jni",
+ "once_cell",
  "serial_test",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +77,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +129,83 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -155,11 +251,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "hier"
 version = "0.1.0"
 dependencies = [
  "graphviz-rust",
  "jni",
+ "serial_test",
  "thiserror",
 ]
 
@@ -248,6 +351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +377,29 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "pest"
@@ -309,6 +445,18 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -396,6 +544,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serial_test"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +584,21 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "syn"
@@ -567,6 +761,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
@@ -588,6 +797,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
@@ -597,6 +812,12 @@ name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -612,6 +833,12 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
@@ -621,6 +848,12 @@ name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -636,6 +869,12 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
@@ -648,6 +887,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
@@ -657,6 +902,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ version = "0.1.0"
 dependencies = [
  "graphviz-rust",
  "jni",
+ "thiserror",
 ]
 
 [[package]]
@@ -295,7 +296,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -317,18 +318,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -418,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.35"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bf04c28bee9043ed9ea1e41afc0552288d3aba9c6efdd78903b802926f4879"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -442,22 +443,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,8 @@ jni = { version = "0.21.1", features = ["invocation"] }
 graphviz-rust = { version = "0.7.0", optional = true }
 thiserror = { version = "1.0.56" }
 
+[dev-dependencies]
+serial_test = "3.0.0"
+
 [features]
 graph = ["dep:graphviz-rust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = ["ChAoS-UnItY (Kyle Lin) <minecraft.kyle.train@gmail.com>"]
 [dependencies]
 jni = { version = "0.21.1", features = ["invocation"] }
 graphviz-rust = { version = "0.7.0", optional = true }
+thiserror = { version = "1.0.56" }
 
 [features]
 graph = ["dep:graphviz-rust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ authors = ["ChAoS-UnItY (Kyle Lin) <minecraft.kyle.train@gmail.com>"]
 jni = { version = "0.21.1", features = ["invocation"] }
 graphviz-rust = { version = "0.7.0", optional = true }
 thiserror = { version = "1.0.56" }
+once_cell = { version = "1.19.0" }
 
 [dev-dependencies]
 serial_test = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ to use cached classes, use `HierExt::lookup_class`. To release the cache, use `H
 Additionally, `HierExt::common_superclass` always uses cached class to find.
 
 ## License
-
+Hier is licensed under MIT License.

--- a/src/class.rs
+++ b/src/class.rs
@@ -1,19 +1,20 @@
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{OnceLock, RwLock};
 
 use jni::descriptors::Desc;
 use jni::objects::{GlobalRef, JClass, JObjectArray, JValueGen, JValueOwned};
 use jni::JNIEnv;
 
+use crate::errors::HierResult as Result;
 use crate::version::JavaVersion;
 
 pub const OBJECT_CLASS_PATH: &'static str = "java/lang/Object";
 
 pub type ClassCache = HashMap<String, GlobalRef>;
 
-fn class_cache() -> &'static Mutex<ClassCache> {
-    static CLASS_CACHE: OnceLock<Mutex<ClassCache>> = OnceLock::new();
-    CLASS_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+fn class_cache() -> &'static RwLock<ClassCache> {
+    static CLASS_CACHE: OnceLock<RwLock<ClassCache>> = OnceLock::new();
+    CLASS_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 // fn jclass_cache() -> &'static mut ClassCache {
@@ -25,16 +26,23 @@ fn class_cache() -> &'static Mutex<ClassCache> {
 /// from JNI interface if not. After each successful fetching operation, [GlobalRef] (JClass)
 /// instance will exist until the termination of program, if this is not desired,
 /// use [free_jclass_cache] to free cache.
-fn jclass(env: &mut JNIEnv, class_path: &str) -> jni::errors::Result<GlobalRef> {
-    let mut cache = class_cache().lock().unwrap();
+fn jclass(env: &mut JNIEnv, class_path: &str) -> Result<GlobalRef> {
+    let cache = class_cache().read()?;
 
-    let class = env.find_class(class_path)?;
-    let glob_ref = env.new_global_ref(class)?;
+    if let Some(cached_class) = cache.get(class_path) {
+        Ok(cached_class.clone())
+    } else {
+        drop(cache);
+        let mut cache = class_cache().write()?;
 
-    Ok(cache
-        .entry(class_path.to_string())
-        .or_insert(glob_ref)
-        .clone())
+        let class = env.find_class(class_path)?;
+        let glob_ref = env.new_global_ref(class)?;
+
+        Ok(cache
+            .entry(class_path.to_string())
+            .or_insert(glob_ref)
+            .clone())
+    }
 }
 
 /// Fetch an [GlobalRef] (JClass) from cache, either:
@@ -42,32 +50,37 @@ fn jclass(env: &mut JNIEnv, class_path: &str) -> jni::errors::Result<GlobalRef> 
 /// 2. Existing JClass with same class path are not same instance, then cache and return the
 ///    provided one
 /// 3. JClass is not cached, then cache and return the provided one
-fn jclass_from_instance<'local>(
+fn jclass_from_instance<'local, 'other_local, T>(
     env: &mut JNIEnv<'local>,
-    instance: &JClass<'local>,
-) -> jni::errors::Result<GlobalRef> {
-    let mut cache = class_cache().lock().unwrap();
+    instance: T,
+) -> Result<GlobalRef> where T: Desc<'local, JClass<'other_local>> {
+    let cache = class_cache().read()?;
 
+    let instance = instance.lookup(env)?;
+    let instance = instance.as_ref();
     let instance_class_path = env.class_name(instance)?;
+
+    if let Some(glob_ref) = cache.get(&instance_class_path) {
+        if env.is_same_object(&glob_ref, instance)? {
+            return Ok(glob_ref.clone());
+        }
+    }
+
+    drop(cache);
+
+    let mut cache = class_cache().write()?;
     let instance_glob_ref = env.new_global_ref(instance)?;
 
-    if let Some(glob_ref) = cache.get_mut(&instance_class_path) {
-        if env.is_same_object(&glob_ref, &instance_glob_ref)? {
-            Ok(glob_ref.clone())
-        } else {
-            *glob_ref = instance_glob_ref.clone();
-            Ok(instance_glob_ref)
-        }
-    } else {
-        cache.insert(instance_class_path.to_string(), instance_glob_ref.clone());
+    cache.insert(instance_class_path.to_string(), instance_glob_ref.clone());
 
-        Ok(instance_glob_ref)
-    }
+    Ok(instance_glob_ref)
 }
 
 /// Frees jclass cache.
-fn free_jclass_cache() {
-    class_cache().lock().unwrap().clear();
+fn free_jclass_cache() -> Result<()> {
+    class_cache().write()?.clear();
+
+    Ok(())
 }
 
 /// The additional definition for [JNIEnv], used for define
@@ -75,33 +88,30 @@ fn free_jclass_cache() {
 /// and other useful class-related functions.
 pub trait HierExt<'local> {
     /// Gets the java version currently the jni environment is running on.
-    fn get_java_version(&mut self) -> jni::errors::Result<JavaVersion>;
+    fn get_java_version(&mut self) -> Result<JavaVersion>;
 
     /// Lookups class from given class path, if class is found, then caches and returns
     /// it.
-    fn lookup_class(&mut self, class_path: &str) -> jni::errors::Result<GlobalRef>;
+    fn lookup_class(&mut self, class_path: &str) -> Result<GlobalRef>;
 
     /// Lookups superclass from given class instance, if superclass is found, then
     /// caches and returns, otherwise, returns [None].
-    fn lookup_superclass<'other_local, T>(
-        &mut self,
-        class: T,
-    ) -> jni::errors::Result<Option<GlobalRef>>
+    fn lookup_superclass<'other_local, T>(&mut self, class: T) -> Result<Option<GlobalRef>>
     where
         T: Desc<'local, JClass<'other_local>>;
 
     /// Frees the class cache.
-    fn free_lookup(&mut self) {
-        free_jclass_cache();
+    fn free_lookup(&mut self) -> Result<()> {
+        free_jclass_cache()
     }
 
     /// Determines if the given class is an interface type.
-    fn is_interface<'other_local, T>(&mut self, class: T) -> jni::errors::Result<bool>
+    fn is_interface<'other_local, T>(&mut self, class: T) -> Result<bool>
     where
         T: Desc<'local, JClass<'other_local>>;
 
     /// Returns the given class' class path.
-    fn class_name<'other_local, T>(&mut self, class: T) -> jni::errors::Result<String>
+    fn class_name<'other_local, T>(&mut self, class: T) -> Result<String>
     where
         T: Desc<'local, JClass<'other_local>>;
 
@@ -118,7 +128,7 @@ pub trait HierExt<'local> {
     ///
     /// Calling [HierExt::interfaces] returns `[JClass("java/lang/Comparable")]`,
     /// notice that this does collects interfaces derived by superclasses.
-    fn interfaces<'other_local, T>(&mut self, class: T) -> jni::errors::Result<Vec<GlobalRef>>
+    fn interfaces<'other_local, T>(&mut self, class: T) -> Result<Vec<GlobalRef>>
     where
         T: Desc<'local, JClass<'other_local>>;
 
@@ -129,14 +139,14 @@ pub trait HierExt<'local> {
         &mut self,
         class1: T,
         class2: U,
-    ) -> jni::errors::Result<GlobalRef>
+    ) -> Result<GlobalRef>
     where
         T: Desc<'local, JClass<'other_local_1>>,
         U: Desc<'local, JClass<'other_local_2>>;
 }
 
 impl<'local> HierExt<'local> for JNIEnv<'local> {
-    fn get_java_version(&mut self) -> jni::errors::Result<JavaVersion> {
+    fn get_java_version(&mut self) -> Result<JavaVersion> {
         let sys_class = self.find_class("java/lang/System")?;
         let property = self.new_string("java.specification.version")?;
         let version = self
@@ -150,16 +160,14 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
 
         self.get_string((&version).into())
             .map(|java_str| JavaVersion::from(Into::<String>::into(java_str)))
+            .map_err(Into::into)
     }
 
-    fn lookup_class(&mut self, class_path: &str) -> jni::errors::Result<GlobalRef> {
+    fn lookup_class(&mut self, class_path: &str) -> Result<GlobalRef> {
         jclass(self, class_path)
     }
 
-    fn lookup_superclass<'other_local, T>(
-        &mut self,
-        class: T,
-    ) -> jni::errors::Result<Option<GlobalRef>>
+    fn lookup_superclass<'other_local, T>(&mut self, class: T) -> Result<Option<GlobalRef>>
     where
         T: Desc<'local, JClass<'other_local>>,
     {
@@ -171,7 +179,7 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         jclass_from_instance(self, &superclass_instance).map(Option::Some)
     }
 
-    fn is_interface<'other_local, T>(&mut self, class: T) -> jni::errors::Result<bool>
+    fn is_interface<'other_local, T>(&mut self, class: T) -> Result<bool>
     where
         T: Desc<'local, JClass<'other_local>>,
     {
@@ -179,9 +187,10 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
 
         self.call_method(class.as_ref(), "isInterface", "()Z", &[])
             .and_then(JValueOwned::z)
+            .map_err(Into::into)
     }
 
-    fn class_name<'other_local, T>(&mut self, class: T) -> jni::errors::Result<String>
+    fn class_name<'other_local, T>(&mut self, class: T) -> Result<String>
     where
         T: Desc<'local, JClass<'other_local>>,
     {
@@ -192,9 +201,10 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
 
         self.get_string((&class_name).into())
             .map(|name| Into::<String>::into(name).replace(".", "/"))
+            .map_err(Into::into)
     }
 
-    fn interfaces<'other_local, T>(&mut self, class: T) -> jni::errors::Result<Vec<GlobalRef>>
+    fn interfaces<'other_local, T>(&mut self, class: T) -> Result<Vec<GlobalRef>>
     where
         T: Desc<'local, JClass<'other_local>>,
     {
@@ -208,7 +218,8 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
 
         for i in 0..interfaces_len {
             let class = self.get_object_array_element(&interfaces_arr, i)?;
-            let cached_class = jclass_from_instance(self, (&class).into())?;
+            let class: &JClass = (&class).into();
+            let cached_class = jclass_from_instance(self, class)?;
 
             interfaces.push(cached_class);
         }
@@ -220,17 +231,17 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         &mut self,
         class1: T,
         class2: U,
-    ) -> jni::errors::Result<GlobalRef>
+    ) -> Result<GlobalRef>
     where
         T: Desc<'local, JClass<'other_local_1>>,
         U: Desc<'local, JClass<'other_local_2>>,
     {
         let class1 = class1.lookup(self)?;
         let class2 = class2.lookup(self)?;
-        let class1 = class1.as_ref();
-        let class2 = class2.as_ref();
-        let mut cls1 = jclass_from_instance(self, class1.as_ref())?;
-        let cls2 = jclass_from_instance(self, class2.as_ref())?;
+        let class1: &JClass = class1.as_ref();
+        let class2: &JClass = class2.as_ref();
+        let mut cls1 = jclass_from_instance(self, class1)?;
+        let cls2 = jclass_from_instance(self, class2)?;
 
         if self.is_assignable_from(&cls2, &cls1)? {
             return Ok(cls1);
@@ -253,7 +264,9 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
             !self.is_assignable_from(&cls2, &cls1)?
         } {}
 
-        jclass_from_instance(self, cls1.as_obj().as_ref().into())
+        let cls1: &JClass = cls1.as_obj().as_ref().into();
+
+        jclass_from_instance(self, cls1)
     }
 }
 
@@ -261,26 +274,27 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
 mod test {
     use crate::{
         class::{class_cache, HierExt},
+        errors::HierResult,
         jni_env,
     };
 
     #[test]
-    fn test_lookup_caching() -> jni::errors::Result<()> {
+    fn test_lookup_caching() -> HierResult<()> {
         let mut env = jni_env();
         let _class1 = env.lookup_class("java/lang/Object")?;
 
         // We can't actually expect how many classes has been look up
         // assert_eq!(class_cache().lock().unwrap().len(), 1);
 
-        env.free_lookup();
+        env.free_lookup()?;
 
-        assert_eq!(class_cache().lock().unwrap().len(), 0);
+        assert_eq!(class_cache().read()?.len(), 0);
 
         Ok(())
     }
 
     #[test]
-    fn test_number_common_super_class() -> jni::errors::Result<()> {
+    fn test_number_common_super_class() -> HierResult<()> {
         let mut env = jni_env();
         let class1 = env.lookup_class("java/lang/Integer")?;
         let class2 = env.lookup_class("java/lang/Float")?;
@@ -297,7 +311,7 @@ mod test {
     )]
     /// Tests all implemented interfaces on `java/lang/Integer`
     /// (non recursively to super class which is `java/lang/Number`)
-    fn test_interfaces() -> jni::errors::Result<()> {
+    fn test_interfaces() -> HierResult<()> {
         let implemented_interfaces = if cfg!(any(jvm_v8, jvm_v11)) {
             vec!["java/lang/Comparable"]
         } else if cfg!(any(jvm_v17, jvm_v21)) {
@@ -316,7 +330,7 @@ mod test {
         let interface_names = interfaces
             .iter()
             .map(|interface| env.class_name(interface))
-            .collect::<jni::errors::Result<Vec<_>>>()?;
+            .collect::<HierResult<Vec<_>>>()?;
 
         assert_eq!(implemented_interfaces, interface_names);
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -4,6 +4,7 @@ use std::sync::{Mutex, OnceLock};
 use jni::descriptors::Desc;
 use jni::objects::{GlobalRef, JClass, JObjectArray, JValueGen, JValueOwned};
 use jni::JNIEnv;
+use jni::strings::JavaStr;
 
 use crate::version::JavaVersion;
 
@@ -189,11 +190,9 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         let class_name = self
             .call_method(class.as_ref(), "getName", "()Ljava/lang/String;", &[])
             .and_then(JValueOwned::l)?;
-        unsafe {
-            self.get_string_unchecked((&class_name).into())
-                .map(|java_str| java_str.into())
-        }
-        .map(|name: String| name.replace(".", "/"))
+
+        self.get_string((&class_name).into())
+            .map(|name| Into::<String>::into(name).replace(".", "/"))
     }
 
     fn interfaces<'other_local, T>(&mut self, class: T) -> jni::errors::Result<Vec<JClass<'local>>>

--- a/src/class.rs
+++ b/src/class.rs
@@ -280,7 +280,7 @@ mod test {
     #[test]
     #[serial]
     fn test_lookup_caching() -> HierResult<()> {
-        let mut env = jni_env();
+        let mut env = jni_env()?;
         let _class1 = env.lookup_class("java/lang/Object")?;
 
         assert_eq!(class_cache().lock()?.len(), 1);
@@ -295,7 +295,7 @@ mod test {
     #[test]
     #[serial]
     fn test_number_common_super_class() -> HierResult<()> {
-        let mut env = jni_env();
+        let mut env = jni_env()?;
         let class1 = env.lookup_class("java/lang/Integer")?;
         let class2 = env.lookup_class("java/lang/Float")?;
         let superclass = env.common_superclass(&class1, &class2)?;
@@ -327,7 +327,7 @@ mod test {
             unreachable!()
         };
 
-        let mut env = jni_env();
+        let mut env = jni_env()?;
         let class = env.lookup_class("java/lang/Integer")?;
         let interfaces = env.interfaces(&class)?;
         let interface_names = interfaces

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,8 +15,6 @@ pub enum HierError {
     JniError(#[from] JniError),
     #[error(transparent)]
     StartJvmError(#[from] StartJvmError),
-    #[error("attempt to fetch existed JVM but JVM has already failed to initialized")]
-    InitializeJvmFailedError,
     #[error("unable to access to class cache, reason: {0}")]
     CacheAccessError(&'static str),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,24 @@
+use std::sync::PoisonError;
+
+use jni::errors::{JniError, StartJvmError};
+use thiserror::Error;
+
+pub type HierResult<T> = Result<T, HierError>;
+
+#[derive(Error, Debug)]
+pub enum HierError {
+    #[error(transparent)]
+    JavaError(#[from] jni::errors::Error),
+    #[error(transparent)]
+    JniError(#[from] JniError),
+    #[error(transparent)]
+    StartJvmError(#[from] StartJvmError),
+    #[error("unable to access to class cache, reason: {0}")]
+    CacheAccessError(&'static str),
+}
+
+impl<T> From<PoisonError<T>> for HierError {
+    fn from(_value: PoisonError<T>) -> Self {
+        Self::CacheAccessError("PoisonError")
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,9 +10,13 @@ pub enum HierError {
     #[error(transparent)]
     JavaError(#[from] jni::errors::Error),
     #[error(transparent)]
+    JvmError(#[from] jni::JvmError),
+    #[error(transparent)]
     JniError(#[from] JniError),
     #[error(transparent)]
     StartJvmError(#[from] StartJvmError),
+    #[error("attempt to fetch existed JVM but JVM has already failed to initialized")]
+    InitializeJvmFailedError,
     #[error("unable to access to class cache, reason: {0}")]
     CacheAccessError(&'static str),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Once};
 use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
 
 pub mod class;
+mod errors;
 #[cfg(feature = "graph")]
 pub mod graph;
 pub mod version;

--- a/src/version.rs
+++ b/src/version.rs
@@ -74,7 +74,7 @@ impl From<String> for JavaVersion {
 
 #[cfg(test)]
 mod test {
-    use crate::{class::HierExt, jni_env, version::JavaVersion};
+    use crate::{class::HierExt, errors::HierResult, jni_env, version::JavaVersion};
 
     #[test]
     #[cfg_attr(
@@ -86,7 +86,7 @@ mod test {
         ignore = "No Java version provided"
     )]
     /// Tests all possible jvm versions
-    fn test_jvm_version() -> jni::errors::Result<()> {
+    fn test_jvm_version() -> HierResult<()> {
         let current_jvm_version: JavaVersion = if cfg!(jvm_v0) {
             JavaVersion::V0
         } else if cfg!(jvm_v1) {

--- a/src/version.rs
+++ b/src/version.rs
@@ -139,7 +139,7 @@ mod test {
             unreachable!()
         };
 
-        let mut env = jni_env();
+        let mut env = jni_env()?;
         let version = env.get_java_version()?;
 
         assert_eq!(current_jvm_version, version);


### PR DESCRIPTION
- Introduce Hier's own error type `crate::errors::HierError` as a wrapper to various error types introduced by `jni` crate.
- Enhance function signatures in `crate::class::HierExt`:
  - Clearify parameters lifetime
  - Replace concrete parameter type `JClass<_>` with generic parameter type `T where T: Desc<_, JClass<_>>`