### PR TITLE
Introduce wrapper to avoid direct operations to JNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ e.g. `JAVA_HOME`).
 
 ```rs
 use hier::jni_env;
-use hier::class::{ HierExt };
+use hier::HierExt;
 
 fn main() {
-    let mut env = jni_env();
-    let integer_class = env.lookup_class("java/lang/Integer").unwrap();
-    let float_class = env.lookup_class("java/lang/Float").unwrap();
-    let common_superclass = env.common_superclass(&integer_class, &float_class).unwrap();
-    let cs_class_name = env.class_name(&common_superclass).unwrap();
+    let mut env = jni_env().unwrap();
+    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut float_class = env.lookup_class("java/lang/Float").unwrap();
+    let mut common_superclass = integer_class.common_superclass(&mut env, &mut float_class).unwrap();
+    let cs_class_name = common_superclass.class_name(&mut env).unwrap();
 
     println!("{cs_class_name}");
 }
@@ -32,18 +32,18 @@ fn main() {
 
 ```rs
 use hier::jni_env;
-use hier::class::{ HierExt };
+use hier::HierExt;
 
 fn main() {
-    let mut env = jni_env();
-    let integer_class = env.lookup_class("java/lang/Integer").unwrap();
-    let interfaces = env.interfaces(&integer_class).unwrap();
-    let interface_names = interfaces.iter()
-        .map(|interface_class| env.class_name(interface_class))
-        .collect::<Result<_, Vec<_>>>()
+    let mut env = jni_env().unwrap();
+    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut interfaces = integer_class.interfaces(&mut env).unwrap();
+    let interface_names = interfaces.iter_mut()
+        .map(|interface_class| interface_class.class_name(&mut env))
+        .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    println!("{cs_class_name}");
+    println!("{interface_names:#?}");
 }
 ```
 

--- a/examples/common_superclass.rs
+++ b/examples/common_superclass.rs
@@ -1,0 +1,12 @@
+use hier::jni_env;
+use hier::HierExt;
+
+fn main() {
+    let mut env = jni_env().unwrap();
+    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut float_class = env.lookup_class("java/lang/Float").unwrap();
+    let mut common_superclass = integer_class.common_superclass(&mut env, &mut float_class).unwrap();
+    let cs_class_name = common_superclass.class_name(&mut env).unwrap();
+
+    println!("{cs_class_name}");
+}

--- a/examples/interfaces.rs
+++ b/examples/interfaces.rs
@@ -1,0 +1,14 @@
+use hier::jni_env;
+use hier::HierExt;
+
+fn main() {
+    let mut env = jni_env().unwrap();
+    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut interfaces = integer_class.interfaces(&mut env).unwrap();
+    let interface_names = interfaces.iter_mut()
+        .map(|interface_class| interface_class.class_name(&mut env))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    println!("{interface_names:#?}");
+}

--- a/src/class.rs
+++ b/src/class.rs
@@ -17,11 +17,6 @@ fn class_cache() -> &'static Mutex<ClassCache> {
     CLASS_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-// fn jclass_cache() -> &'static mut ClassCache {
-//     static CACHE: OnceLock<ClassCache> = OnceLock::new();
-//     CACHE.get_or_init(|| HashMap::new())
-// }
-
 /// Fetch an [GlobalRef] (JClass) either from cache if already fetched before, or directly
 /// from JNI interface if not. After each successful fetching operation, [GlobalRef] (JClass)
 /// instance will exist until the termination of program, if this is not desired,

--- a/src/class.rs
+++ b/src/class.rs
@@ -132,7 +132,7 @@ impl Class {
     ) -> Result<&Vec<Arc<Mutex<Class>>>> {
         self.interfaces.get_or_try_init(|| {
             let method_id =
-                env.get_method_id(Self::CLASS_CP, "getModifiers", "()[Ljava/lang/Class;")?;
+                env.get_method_id(Self::CLASS_CP, "getInterfaces", "()[Ljava/lang/Class;")?;
             let interface_arr: JObjectArray = unsafe {
                 env.call_method_unchecked(&self.inner, method_id, ReturnType::Array, &[])
                     .and_then(JValueGen::l)?

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub enum HierError {
     StartJvmError(#[from] StartJvmError),
     #[error("unable to access to class cache, reason: {0}")]
     CacheAccessError(&'static str),
+    #[error("unable to find the class {0} in the cache, Class probably had been freed up")]
+    DanglingClassError(String),
 }
 
 impl<T> From<PoisonError<T>> for HierError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod class;
 mod errors;
 #[cfg(feature = "graph")]
 pub mod graph;
+mod modifiers;
 pub mod version;
 
 pub extern crate jni;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,21 @@
 #![doc = include_str!("../README.md")]
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    ops::Deref,
+    sync::{Arc, Mutex, OnceLock},
+};
 
+use class::{Class, ClassInternal};
 use errors::HierResult as Result;
-use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
+use jni::{
+    descriptors::Desc,
+    objects::{JClass, JValueGen},
+    signature::ReturnType,
+    InitArgsBuilder, JNIEnv, JNIVersion, JavaVM,
+};
 use once_cell::sync::OnceCell;
+use version::JavaVersion;
 
 pub mod class;
 mod errors;
@@ -34,4 +45,142 @@ fn jvm() -> Result<&'static Arc<JavaVM>> {
 /// Get JNI environment instance, notice that the thread is attached permanently.
 pub fn jni_env() -> Result<JNIEnv<'static>> {
     jvm().and_then(|jvm| jvm.attach_current_thread_permanently().map_err(Into::into))
+}
+
+pub type ClassCache = HashMap<String, Arc<Mutex<ClassInternal>>>;
+
+fn class_cache() -> &'static Mutex<ClassCache> {
+    static CLASS_CACHE: OnceLock<Mutex<ClassCache>> = OnceLock::new();
+    CLASS_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Fetch an [GlobalRef] (JClass) either from cache if already fetched before, or directly
+/// from JNI interface if not. After each successful fetching operation, [GlobalRef] (JClass)
+/// instance will exist until the termination of program, if this is not desired,
+/// use [free_jclass_cache] to free cache.
+fn fetch_class<'local>(
+    env: &mut JNIEnv<'local>,
+    class_path: &str,
+) -> Result<Arc<Mutex<ClassInternal>>> {
+    let cache = class_cache().lock()?;
+
+    if let Some(cached_class) = cache.get(class_path) {
+        Ok(cached_class.clone())
+    } else {
+        drop(cache);
+        let jclass = env.find_class(class_path)?;
+        fetch_class_from_jclass(env, jclass)
+    }
+}
+
+fn fetch_class_from_jclass<'local, 'other_local>(
+    env: &mut JNIEnv<'local>,
+    jclass: JClass<'other_local>,
+) -> Result<Arc<Mutex<ClassInternal>>> {
+    let jclass_cp = env.class_name(&jclass)?;
+
+    fetch_class_from_jclass_internal(env, jclass, &jclass_cp)
+}
+
+fn fetch_class_from_jclass_internal<'local, 'other_local>(
+    env: &mut JNIEnv<'local>,
+    jclass: JClass<'other_local>,
+    known_jclass_cp: &str,
+) -> Result<Arc<Mutex<ClassInternal>>> {
+    let mut cache = class_cache().lock()?;
+    let glob_ref = env.new_global_ref(jclass)?;
+    let class = Arc::new(Mutex::new(ClassInternal::new(glob_ref)));
+    let weak_class_self_ref = Arc::downgrade(&class);
+    unsafe {
+        let mut class_guard = class.lock()?;
+        class_guard.initialize_self_weak_ref(weak_class_self_ref);
+    }
+
+    Ok(cache
+        .entry(known_jclass_cp.to_string())
+        .or_insert(class)
+        .clone())
+}
+
+/// Frees jclass cache.
+unsafe fn free_jclass_cache() -> Result<()> {
+    class_cache().lock()?.clear();
+
+    Ok(())
+}
+
+/// The additional definition for [JNIEnv], used for define
+/// [JClass] caching (see [HierExt::lookup_class] and [HierExt::free_lookup])
+/// and other useful class-related functions.
+pub trait HierExt<'local> {
+    /// Gets the java version currently the jni environment is running on.
+    fn get_java_version(&mut self) -> Result<JavaVersion>;
+
+    /// Lookups class from given class path, if class is found, then caches and returns
+    /// it.
+    fn lookup_class(&mut self, class_path: &str) -> Result<Class>;
+
+    /// Frees the class cache.
+    ///
+    /// # Safety
+    ///
+    /// This could cause current existed unfreed [Class] to be unreliable,
+    /// you'll need to get another instance of [Class] through [HierExt::lookup_class].
+    ///
+    /// Calling to existed unfreed [Class] would lead to undefined behaviour.
+    unsafe fn free_lookup(&mut self) -> Result<()> {
+        free_jclass_cache()
+    }
+
+    /// Returns the given class' class path.
+    fn class_name<'other_local, T>(&mut self, class: T) -> Result<String>
+    where
+        T: Desc<'local, JClass<'other_local>>;
+}
+
+impl<'local> HierExt<'local> for JNIEnv<'local> {
+    fn get_java_version(&mut self) -> Result<JavaVersion> {
+        let sys_class = self.find_class("java/lang/System")?;
+        let property = self.auto_local(self.new_string("java.specification.version")?);
+        let version = self
+            .call_static_method(
+                sys_class,
+                "getProperty",
+                "(Ljava/lang/String;)Ljava/lang/String;",
+                &[(&property).into()],
+            )
+            .and_then(JValueGen::l)?;
+        let version = self.auto_local(version);
+
+        unsafe {
+            self.get_string_unchecked(version.deref().into())
+                .map(|java_str| JavaVersion::from(Into::<String>::into(java_str)))
+                .map_err(Into::into)
+        }
+    }
+
+    fn lookup_class(&mut self, class_path: &str) -> Result<Class> {
+        fetch_class(self, class_path).map(Class::new)
+    }
+
+    fn class_name<'other_local, T>(&mut self, class: T) -> Result<String>
+    where
+        T: Desc<'local, JClass<'other_local>>,
+    {
+        let class = class.lookup(self)?;
+        let method_id =
+            self.get_method_id(ClassInternal::CLASS_CP, "getName", "()Ljava/lang/String;")?;
+        let class_name = unsafe {
+            self.call_method_unchecked(class.as_ref(), method_id, ReturnType::Object, &[])
+                .and_then(JValueGen::l)?
+        };
+        let class_name = self.auto_local(class_name);
+
+        unsafe {
+            self.get_string_unchecked(class_name.deref().into())
+                .map(Into::<String>::into)
+                .map(|name| name.replace(".", "/"))
+                .map_err(Into::into)
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,22 +69,22 @@ fn fetch_class<'local>(
     } else {
         drop(cache);
         let jclass = env.find_class(class_path)?;
-        fetch_class_from_jclass(env, jclass)
+        fetch_class_from_jclass(env, &jclass)
     }
 }
 
 fn fetch_class_from_jclass<'local, 'other_local>(
     env: &mut JNIEnv<'local>,
-    jclass: JClass<'other_local>,
+    jclass: &JClass<'other_local>,
 ) -> Result<Arc<Mutex<ClassInternal>>> {
-    let jclass_cp = env.class_name(&jclass)?;
+    let jclass_cp = env.class_name(jclass)?;
 
     fetch_class_from_jclass_internal(env, jclass, &jclass_cp)
 }
 
 fn fetch_class_from_jclass_internal<'local, 'other_local>(
     env: &mut JNIEnv<'local>,
-    jclass: JClass<'other_local>,
+    jclass: &JClass<'other_local>,
     known_jclass_cp: &str,
 ) -> Result<Arc<Mutex<ClassInternal>>> {
     let mut cache = class_cache().lock()?;

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -1,0 +1,33 @@
+use std::ops::BitAnd;
+
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Modifiers {
+    Public = 0x0001,
+    Final = 0x0010,
+    Interface = 0x0200,
+}
+
+impl BitAnd for Modifiers {
+    type Output = u16;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        (self as u16) & (rhs as u16)
+    }
+}
+
+impl BitAnd<Modifiers> for u16 {
+    type Output = u16;
+
+    fn bitand(self, rhs: Modifiers) -> Self::Output {
+        self & (rhs as u16)
+    }
+}
+
+impl BitAnd<u16> for Modifiers {
+    type Output = u16;
+
+    fn bitand(self, rhs: u16) -> Self::Output {
+        (self as u16) & rhs
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -74,7 +74,7 @@ impl From<String> for JavaVersion {
 
 #[cfg(test)]
 mod test {
-    use crate::{class::HierExt, errors::HierResult, jni_env, version::JavaVersion};
+    use crate::{errors::HierResult, jni_env, version::JavaVersion, HierExt};
 
     #[test]
     #[cfg_attr(


### PR DESCRIPTION
- Introduce struct `Class` as wrapper class of `JClass` in `GlobalRef` form. This also makes class info caching possible.
- Migrate functions from `HierExt` to `Class`.

This PR is part of #2.