### PR TITLE
Add `classpath::ClassPath` for better JNI/Java side class path usage integretion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ use hier::HierExt;
 
 fn main() {
     let mut env = jni_env().unwrap();
-    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
-    let mut float_class = env.lookup_class("java/lang/Float").unwrap();
+    let mut integer_class = env.lookup_class("java.lang.Integer").unwrap();
+    let mut float_class = env.lookup_class("java.lang.Float").unwrap();
     let mut common_superclass = integer_class.common_superclass(&mut env, &mut float_class).unwrap();
     let cs_class_name = common_superclass.class_name(&mut env).unwrap();
 
@@ -36,7 +36,7 @@ use hier::HierExt;
 
 fn main() {
     let mut env = jni_env().unwrap();
-    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut integer_class = env.lookup_class("java.lang.Integer").unwrap();
     let mut interfaces = integer_class.interfaces(&mut env).unwrap();
     let interface_names = interfaces.iter_mut()
         .map(|interface_class| interface_class.class_name(&mut env))

--- a/examples/common_superclass.rs
+++ b/examples/common_superclass.rs
@@ -3,8 +3,8 @@ use hier::HierExt;
 
 fn main() {
     let mut env = jni_env().unwrap();
-    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
-    let mut float_class = env.lookup_class("java/lang/Float").unwrap();
+    let mut integer_class = env.lookup_class("java.lang.Integer").unwrap();
+    let mut float_class = env.lookup_class("java.lang.Float").unwrap();
     let mut common_superclass = integer_class
         .common_superclass(&mut env, &mut float_class)
         .unwrap();

--- a/examples/interfaces.rs
+++ b/examples/interfaces.rs
@@ -3,7 +3,7 @@ use hier::HierExt;
 
 fn main() {
     let mut env = jni_env().unwrap();
-    let mut integer_class = env.lookup_class("java/lang/Integer").unwrap();
+    let mut integer_class = env.lookup_class("java.lang.Integer").unwrap();
     let mut interfaces = integer_class.interfaces(&mut env).unwrap();
     let interface_names = interfaces
         .iter_mut()

--- a/src/classpath.rs
+++ b/src/classpath.rs
@@ -1,0 +1,76 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClassPath {
+    Java(String),
+    JNI(String),
+}
+
+impl ClassPath {
+    pub fn convert(&self) -> Self {
+        match self {
+            Self::Java(cp) => {
+                let mut jni_cp = cp.replace(".", "/").replace("[]", "");
+                let array_dim = cp.matches("[]").count();
+
+                if array_dim > 0 {
+                    jni_cp = format!("{}L{jni_cp};", "[".repeat(array_dim));
+                }
+
+                Self::JNI(jni_cp)
+            }
+            Self::JNI(cp) => {
+                let mut java_cp = cp.replace("/", ".");
+                let array_dim = cp.matches("[").count();
+
+                if array_dim > 0 {
+                    java_cp = java_cp
+                        .chars()
+                        .skip_while(|c| *c == '[')
+                        .skip(1)
+                        .take_while(|c| *c != ';')
+                        .collect();
+
+                    java_cp = format!("{java_cp}{}", "[]".repeat(array_dim));
+                }
+
+                Self::Java(java_cp)
+            }
+        }
+    }
+
+    pub fn as_jni(self) -> Self {
+        match self {
+            Self::Java(_) => self.convert(),
+            _ => self,
+        }
+    }
+
+    pub fn as_java(self) -> Self {
+        match self {
+            Self::JNI(_) => self.convert(),
+            _ => self,
+        }
+    }
+}
+
+impl Into<String> for ClassPath {
+    fn into(self) -> String {
+        match self {
+            ClassPath::Java(cp) => cp,
+            ClassPath::JNI(cp) => cp,
+        }
+    }
+}
+
+impl From<String> for ClassPath {
+    /// Converts [String] into [ClassPath::Java] by default.
+    fn from(value: String) -> Self {
+        Self::Java(value)
+    }
+}
+
+impl<'a> From<&'a str> for ClassPath {
+    /// Coverts [`&str`](str) into [ClassPath::Java] by default.
+    fn from(value: &'a str) -> Self {
+        Self::Java(value.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,3 +201,29 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{errors::HierResult, jni_env, HierExt};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_lookup_class() -> HierResult<()> {
+        let mut jni = jni_env()?;
+
+        // TODO: Resolve #7 for this
+        // assert_eq!(jni.lookup_class("int")?.name(&mut jni)?, "int");
+        // assert_eq!(jni.lookup_class("int[]")?.name(&mut jni)?, "[I");
+        assert_eq!(
+            jni.lookup_class("java.lang.Class")?.name(&mut jni)?,
+            "java.lang.Class"
+        );
+        assert_eq!(
+            jni.lookup_class("java.lang.Class[]")?.name(&mut jni)?,
+            "[Ljava.lang.Class;"
+        );
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use class::{Class, ClassInternal};
+use classpath::ClassPath;
 use errors::HierResult as Result;
 use jni::{
     descriptors::Desc,
@@ -17,6 +18,7 @@ use jni::{
 use once_cell::sync::OnceCell;
 use version::JavaVersion;
 
+pub mod classpath;
 mod errors;
 #[cfg(feature = "graph")]
 pub mod graph;
@@ -123,7 +125,9 @@ pub trait HierExt<'local> {
 
     /// Lookups class from given class path, if class is found, then caches and returns
     /// it.
-    fn lookup_class(&mut self, class_path: &str) -> Result<Class>;
+    fn lookup_class<CP>(&mut self, class_path: CP) -> Result<Class>
+    where
+        CP: Into<ClassPath>;
 
     /// Frees the class cache.
     ///
@@ -164,8 +168,13 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         }
     }
 
-    fn lookup_class(&mut self, class_path: &str) -> Result<Class> {
-        fetch_class(self, class_path).map(Class::new)
+    fn lookup_class<CP>(&mut self, class_path: CP) -> Result<Class>
+    where
+        CP: Into<ClassPath>,
+    {
+        let class_path: String = class_path.into().as_jni().into();
+
+        fetch_class(self, &class_path).map(Class::new)
     }
 
     fn class_name<'other_local, T>(&mut self, class: T) -> Result<String>
@@ -173,8 +182,11 @@ impl<'local> HierExt<'local> for JNIEnv<'local> {
         T: Desc<'local, JClass<'other_local>>,
     {
         let class = class.lookup(self)?;
-        let method_id =
-            self.get_method_id(ClassInternal::CLASS_CP, "getName", "()Ljava/lang/String;")?;
+        let method_id = self.get_method_id(
+            ClassInternal::CLASS_JNI_CP,
+            "getName",
+            "()Ljava/lang/String;",
+        )?;
         let class_name = unsafe {
             self.call_method_unchecked(class.as_ref(), method_id, ReturnType::Object, &[])
                 .and_then(JValueGen::l)?


### PR DESCRIPTION
- Introduce enum `classpath::ClassPath` for better JNI/Java side class path usage integretion (resolves #4)
- Add tests for class lookup